### PR TITLE
fix incorrect variable right(name)

### DIFF
--- a/inc/rulevip.class.php
+++ b/inc/rulevip.class.php
@@ -41,8 +41,8 @@ if (!defined('GLPI_ROOT')) {
 class PluginVipRuleVip extends Rule {
 
    // From Rule
-   public static $right    = 'plugin_vip';
-   public        $can_sort = true;
+   public static $rightname = 'plugin_vip';
+   public        $can_sort  = true;
 
    /**
     * @return translated

--- a/inc/rulevipcollection.class.php
+++ b/inc/rulevipcollection.class.php
@@ -37,7 +37,7 @@ if (!defined('GLPI_ROOT')) {
 class PluginVipRuleVipCollection extends RuleCollection {
 
    // From RuleCollection
-   public static $right       = 'plugin_vip';
+   public static $rightname   = 'plugin_vip';
    public        $menu_option = 'vip';
 
    /**


### PR DESCRIPTION
Hi @tsmr 

Good job for this plugin ! :+1: 
Here is a very small fix on right variables names for rule classes.

Regards,
François.