### PR TITLE
Fix user dropdown pagination

### DIFF
--- a/vip.js
+++ b/vip.js
@@ -110,20 +110,22 @@
                                                 url: CFG_GLPI.root_doc+'/'+GLPI_PLUGINS_PATH.vip+'/ajax/getDropdownUsers.php',
                                                 dataType: 'json',
                                                 type: 'POST',
-                                                data: function (term, page) {
+                                                data: function (params) {
                                                     return {
                                                         all: 0,
                                                         right: 'all',
                                                         used: response.used,
                                                         entity_restrict: response.entities_id,
-                                                        searchText: term.term,
+                                                        searchText: params.term,
                                                         page_limit: object.params['page_limit'], // page size
-                                                        page: page, // page number
+                                                        page: params.page, // page number
                                                     };
                                                 },
-                                                results: function (data, page) {
+                                                processResults: function (data, page) {
                                                     var more = (data.count >= object.params['page_limit']);
-                                                    return {results: data.results, more: more};
+                                                    return {results: data.results, pagination: {
+                                                        more: more
+                                                    }};
                                                 }
                                             },
                                             initSelection: function (element, callback) {
@@ -191,7 +193,7 @@
                                                   $("div[class='responsive_hidden actor_title']").append("<br><br><img id='vip_img' src='" + CFG_GLPI.root_doc + "/" + GLPI_PLUGINS_PATH.vip + "/pics/vip.png'>");
                                               } else if (!ticketVip && !alreadyVip) {
                                                  $("#vip_img").remove();
-                                              } 
+                                              }
                                               return result.text;
                                            },
                                         });


### PR DESCRIPTION
Pagination isn't working on the 1.7.2 (glpi 9.5) version of the plugin.

An easy way to reproduce the bug is to set your dropdown size to 1:
![image](https://user-images.githubusercontent.com/42734840/168089947-d4b92957-dab1-4ef0-95e5-c2863c194e5e.png)

And try to add a requester:
![image](https://user-images.githubusercontent.com/42734840/168090295-572b959b-d0a2-477d-a43f-7135d98355bd.png)

Scrolling down does not load the other users as it would be expected.

Fixed by updating the JS code to match the expected API described in the select2 documentation: https://select2.org/data-sources/ajax#pagination
I suppose this JS code was copied from an older version of GLPI, with an older version of the select2 library which had a different API at that time.

PS: I didn't check the 1.8.0 version for GLPI 10.
You might want to test if this issue affect it
